### PR TITLE
v0.2.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+* Adds special case for `bytes` and `binary` options. Size should be specified before these types.
+
 ## v0.2.0
 
 * Improve AST parser logic to handle 2, 3, and 4 element patterns.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the `:credo_binary_patterns` package to your `mix.exs` dependencies:
 ```elixir
 def deps do
   [
-    {:credo_binary_patterns, "~> 0.2.0", only: [:dev, :test], runtime: false}
+    {:credo_binary_patterns, "~> 0.2.1", only: [:dev, :test], runtime: false}
   ]
 end
 ```
@@ -28,7 +28,7 @@ Add the check to your `.credo.exs` configuration file.
 This check will raise issues if any binary patterns in your code do not follow the expected ordering or formatting.
 
 ```elixir
-{CredoBinaryPatterns.Check.Consistency.Patterns}
+{CredoBinaryPatterns.Check.Consistency.Pattern}
 ```
 
 ## Conventions

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CredoBinaryPatterns.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @source_url "https://github.com/smartrent/credo_binary_patterns"
 
   def project do


### PR DESCRIPTION
## v0.2.1

* Adds special case for `bytes` and `binary` options. Size should be specified before these types.

(Also fixes the module name in README)