### PR TITLE
Assume default type is integer when checking other default options

### DIFF
--- a/lib/credo_binary_patterns/check/consistency/pattern.ex
+++ b/lib/credo_binary_patterns/check/consistency/pattern.ex
@@ -329,6 +329,7 @@ defmodule CredoBinaryPatterns.Check.Consistency.Pattern do
     end
   end
 
+  defp default_size(nil), do: 8
   defp default_size(:integer), do: 8
   defp default_size(:float), do: 64
   defp default_size(:bitstring), do: 1
@@ -338,6 +339,7 @@ defmodule CredoBinaryPatterns.Check.Consistency.Pattern do
   defp default_size(:utf32), do: 32
   defp default_size(_), do: :none
 
+  defp default_endian(nil), do: :big
   defp default_endian(:integer), do: :big
   defp default_endian(:float), do: :big
   defp default_endian(:utf8), do: :big
@@ -347,6 +349,7 @@ defmodule CredoBinaryPatterns.Check.Consistency.Pattern do
   defp default_endian(:bits), do: :none
   defp default_endian(_), do: :none
 
+  defp default_sign(nil), do: :unsigned
   defp default_sign(:integer), do: :unsigned
   defp default_sign(:float), do: :unsigned
   defp default_sign(:utf8), do: :unsigned

--- a/test/credo_binary_patterns/check/consistency/pattern_test.exs
+++ b/test/credo_binary_patterns/check/consistency/pattern_test.exs
@@ -57,6 +57,32 @@ defmodule CredoBinaryPatterns.Check.Consistency.PatternTest do
     |> assert_issue
   end
 
+  test "Should raise an issue by assuming the default type is integer" do
+    """
+    defmodule Test do
+      def some_function(x) do
+        <<x::big-unsigned-32>>
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue
+  end
+
+  test "Should NOT raise an issue by assuming the default type is integer" do
+    """
+    defmodule Test do
+      def some_function(x) do
+        <<x::little-32>>
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues
+  end
+
   ## Bytes
 
   test "Should NOT raise an issue for pattern <<[constant]-bytes>>" do


### PR DESCRIPTION
Bug:

Issue should have been raised for the following code:

```elixir
<<x::big-unsigned-32>>
```

Since the default type of a binary pattern is `integer`, the `unsigned` and `big` options are redundant.