### PR TITLE
Do not allow constant `size(x)` with integers/floats

### DIFF
--- a/test/credo_binary_patterns/check/consistency/pattern_test.exs
+++ b/test/credo_binary_patterns/check/consistency/pattern_test.exs
@@ -137,6 +137,19 @@ defmodule CredoBinaryPatterns.Check.Consistency.PatternTest do
     |> assert_issue
   end
 
+  test "Should raise an issue if size is used with integer" do
+    """
+    defmodule Test do
+      def some_function(x) do
+        <<x::little-integer-size(32)>>
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> assert_issue
+  end
+
   ## Binaries
 
   test "Should raise an issue if constants are used with `binary`" do


### PR DESCRIPTION
Prevents expressions like this:

```elixir
    defmodule Test do
      def some_function(x) do
        <<x::little-integer-size(32)>>
      end
    end
```

Should be re-written as:

```elixir
    defmodule Test do
      def some_function(x) do
        <<x::little-32>>
      end
    end
```