### PR TITLE
v0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+* Treat `bitstring`/`bits` with the same rules as `binary`/`bytes` ([#13](https://github.com/smartrent/credo_binary_patterns/pull/13)).
+* Do not allow `size(constant)` with `interger` and `float`.
+
 ## v0.2.2
 
 * Create more specific rules around `bytes`, `binary`, and `size(x)` in patterns. ([#7](https://github.com/smartrent/credo_binary_patterns/pull/7)).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the `:credo_binary_patterns` package to your `mix.exs` dependencies:
 ```elixir
 def deps do
   [
-    {:credo_binary_patterns, "~> 0.2.2", only: [:dev, :test], runtime: false}
+    {:credo_binary_patterns, "~> 0.2.3", only: [:dev, :test], runtime: false}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CredoBinaryPatterns.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @source_url "https://github.com/smartrent/credo_binary_patterns"
 
   def project do


### PR DESCRIPTION
# Changelog

## v0.2.3

* Treat `bitstring`/`bits` with the same rules as `binary`/`bytes` ([#13](https://github.com/smartrent/credo_binary_patterns/pull/13)).
* Do not allow `size(constant)` with `interger` and `float`.