### PR TITLE
Treat <<::x-bits>> the same as <<::x-bytes>>

### DIFF
--- a/lib/credo_binary_patterns/check/consistency/pattern.ex
+++ b/lib/credo_binary_patterns/check/consistency/pattern.ex
@@ -329,10 +329,10 @@ defmodule CredoBinaryPatterns.Check.Consistency.Pattern do
   # What we do here, is rank each component type with a numeric value corresponding to the proper ordering.
   # If we sort this ranked list, and the result does not match the original list, the pattern is out of order.
   defp in_correct_order?(pattern_info, components) when is_list(components) do
-    # special case, if the type is a binary, size comes before type!
-    is_bytes? = pattern_info.type == :bytes
-    type_order = if is_bytes?, do: 4, else: 3
-    size_order = if is_bytes?, do: 3, else: 4
+    # special case, if the type is a binary or a bitstring size comes before type!
+    is_bytes_or_bits? = pattern_info.type == :bytes || pattern_info.type == :bits
+    type_order = if is_bytes_or_bits?, do: 4, else: 3
+    size_order = if is_bytes_or_bits?, do: 3, else: 4
 
     components_ranked =
       Enum.map(components, fn c ->

--- a/test/credo_binary_patterns/check/consistency/pattern_test.exs
+++ b/test/credo_binary_patterns/check/consistency/pattern_test.exs
@@ -83,6 +83,19 @@ defmodule CredoBinaryPatterns.Check.Consistency.PatternTest do
     |> refute_issues
   end
 
+  test "Should NOT raise an issue when using syntax: <<X-bits>>" do
+    """
+    defmodule Test do
+      def some_function(x) do
+        <<x::4-bits>>
+      end
+    end
+    """
+    |> to_source_file
+    |> run_check(@described_check)
+    |> refute_issues
+  end
+
   test "Should NOT raise an issue when using `unit`" do
     """
     defmodule Test do


### PR DESCRIPTION
* Allow `<<x::4-bits>>` as valid ordering of terms.
* Add unit test to validate change.