### PR TITLE
v0.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.4
+
+* Treat `bytes` and `bits` both as units. Fixes a false warning when using: `<<x::4-bits>>`.
+* Bump dependencies and Elixir version in CI.
+* Update code formatting to be more consistent.
+
 ## v0.2.3
 
 * Treat `bitstring`/`bits` with the same rules as `binary`/`bytes` ([#13](https://github.com/smartrent/credo_binary_patterns/pull/13)).

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CredoBinaryPatterns.MixProject do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
   @source_url "https://github.com/smartrent/credo_binary_patterns"
 
   def project do


### PR DESCRIPTION
## v0.2.4

* Treat `bytes` and `bits` both as units. Fixes a false warning when using: `<<x::4-bits>>`.
* Bump dependencies and Elixir version in CI.
* Update code formatting to be more consistent.