### PR TITLE
Raise issue if size(x) is used on its own

### DIFF
--- a/test/credo_binary_patterns/check/consistency/pattern_test.exs
+++ b/test/credo_binary_patterns/check/consistency/pattern_test.exs
@@ -163,6 +163,19 @@ defmodule CredoBinaryPatterns.Check.Consistency.PatternTest do
     |> assert_issue()
   end
 
+  test "Should raise an issue if size is used with a plain value" do
+    """
+    defmodule Test do
+      def some_function(x) do
+        <<x::size(32)>>
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> assert_issue()
+  end
+
   # Bit Strings
 
   test "Should raise an issue if constants are used with `bitstring`" do


### PR DESCRIPTION
* Recommend:
  * `<<x::size(4)>>` -> `<<x::4>>`
* Fix leaving a trailing `::` in some formatted `stringify/2` results.