### PR TITLE
v0.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+* Suggest patterns in the form of `<<x::size(y)>>` to be rewritten as `<<x::y>>`.
+* Fix suggested pattern strings sometimes having a trailing `::` in Credo output.
+
 ## v0.2.4
 
 * Treat `bytes` and `bits` both as units. Fixes a false warning when using: `<<x::4-bits>>`.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CredoBinaryPatterns.MixProject do
   use Mix.Project
 
-  @version "0.2.4"
+  @version "0.2.5"
   @source_url "https://github.com/smartrent/credo_binary_patterns"
 
   def project do


### PR DESCRIPTION
## v0.2.5

* Suggest patterns in the form of `<<x::size(y)>>` to be rewritten as `<<x::y>>`.
* Fix suggested pattern strings sometimes having a trailing `::` in Credo output.