### PR TITLE
Fix size(variable) causing an issue

### DIFF
--- a/lib/credo_binary_patterns/check/consistency/pattern.ex
+++ b/lib/credo_binary_patterns/check/consistency/pattern.ex
@@ -145,7 +145,8 @@ defmodule CredoBinaryPatterns.Check.Consistency.Pattern do
           [{value_matched, [line: _, column: _], nil}, {:size, _, [size_value]}]} = ast,
          issues,
          issue_meta
-       ) do
+       )
+       when is_integer(size_value) do
     process_traverse(
       value_matched,
       [:size, size_value],

--- a/test/credo_binary_patterns/check/consistency/pattern_test.exs
+++ b/test/credo_binary_patterns/check/consistency/pattern_test.exs
@@ -176,6 +176,19 @@ defmodule CredoBinaryPatterns.Check.Consistency.PatternTest do
     |> assert_issue()
   end
 
+  test "Should NOT raise an issue if size is used with a variable value" do
+    """
+    defmodule Test do
+      def some_function(x) do
+        <<x::size(variable_value)>>
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(@described_check)
+    |> refute_issues()
+  end
+
   # Bit Strings
 
   test "Should raise an issue if constants are used with `bitstring`" do


### PR DESCRIPTION
* Fixes an issue where the `:extraneous_size` rule would be raised when using a variable in a `size` expression.