### PR TITLE
v0.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.6
+
+* Fixes an issue where the `:extraneous_size` rule would be raised when using a variable in a `size` expression.
+
 ## v0.2.5
 
 * Suggest patterns in the form of `<<x::size(y)>>` to be rewritten as `<<x::y>>`.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CredoBinaryPatterns.MixProject do
   use Mix.Project
 
-  @version "0.2.5"
+  @version "0.2.6"
   @source_url "https://github.com/smartrent/credo_binary_patterns"
 
   def project do


### PR DESCRIPTION
## v0.2.6

* Fixes an issue where the `:extraneous_size` rule would be raised when using a variable in a `size` expression.